### PR TITLE
Add historical data support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "api/requirements.txt" }}
+            - v1-dependencies-{{ checksum "app/requirements.txt" }}
             - v1-dependencies-
       - run:
           command: |  
@@ -20,14 +20,14 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            cd api && make setup-venv
+            cd app && make setup-venv
 
       - save_cache:
           paths:
-            - ./api/venv
-          key: v1-dependencies-{{ checksum "api/requirements.txt" }}
+            - ./app/venv
+          key: v1-dependencies-{{ checksum "app/requirements.txt" }}
 
       - run:
           name: run tests
           command: |
-            cd api && make test
+            cd app && make test

--- a/app/api-tests/resources/test_model1.py
+++ b/app/api-tests/resources/test_model1.py
@@ -71,9 +71,19 @@ def test_get_collection_with_pagination(mock_db, client):
 def test_post_collection_success(client):
     body = {
         'pk': 'a',
-        'score': '0.9',
         'modelName': 'model1',
-        'version': 'v1'
+        'version': 'v1',
+        'history': {
+            '2018-01-01': {
+                'score': '9'
+            },
+            '2018-02-01': {
+                'score': 'A+'
+            },
+            '2018-03-01': {
+                'score': 'B-'
+            }
+        }
     }
     result = client.simulate_post(
             path='/v1/model1',
@@ -96,20 +106,24 @@ def test_post_collection_with_wrong_schema(client):
             path='/v1/model1',
             json=body)
     assert result.status == falcon.HTTP_400
-    assert result.json == {'title': 'Failed data validation',
-            'description': '"pk" is a required property for all models'}
 
 def test_put_item_with_success(client):
     body = {
         'pk': 'a',
-        'size': 9,
         'modelName': 'model2',
-        'version': 'v1'
+        'version': 'v1',
+        'history': {
+            '2019-01-01': {
+                'size': 'AAA'
+            },
+            '2019-02-01': {
+                'size': 'AAALarge'
+            }
+        }
     }
     result = client.simulate_put(
             path='/v1/model2/a',
             json=body)
-    assert result.text == ''
     assert result.status == falcon.HTTP_200
 
 def test_put_item_with_wrong_version(client):
@@ -152,8 +166,6 @@ def test_put_item_with_invalid_json_schema(client):
             path='/v1/model1/a',
             json=body)
     assert result.status == falcon.HTTP_400
-    assert result.json == {'title': 'Failed data validation',
-            'description': '"pk" is a required property for all models'}
 
 def test_get_item_with_success(mock_db, client):
     with mock_db.pool().connection() as conn:

--- a/app/api/resources/schema_validator.py
+++ b/app/api/resources/schema_validator.py
@@ -9,12 +9,6 @@ class SchemaValidator:
         self.schema_dict = {}
 
     def validate(self, json_data, version, model_name): 
-        if not 'pk' in json_data.keys():
-            raise falcon.HTTPBadRequest('Failed data validation',
-                    description='"pk" is a required property for all models')
-        if not 'modelName' in json_data.keys():
-            raise falcon.HTTPBadRequest('Failed data validation',
-                    description='"modelName" is a required property for all models')
         try:
             schema = self.schema_dict.get(model_name)
             if not schema:

--- a/app/api/schemas/v1/model1.json
+++ b/app/api/schemas/v1/model1.json
@@ -2,10 +2,19 @@
   "title": "Shema for data model 1",
   "type": "object",
   "properties": {
-    "pk": {"type": "string"},
-    "score": {"type":"string"},
     "modelName": {"type": "string"},
-    "version": {"type":"string"}
+    "pk": {"type": "string"},
+    "version": {"type": "string"},
+    "history": {
+      "type": "object",
+      "patternProperties": {
+        "d{4}-d{2}-d{2}": {
+          "type": "object",
+          "score": {"type": "string"},
+          "required": ["score"]
+        }
+      }
+    }
   },
-  "required": ["pk", "score", "modelName", "version"]
+  "required": ["pk", "version", "history", "modelName"]
 }

--- a/app/api/schemas/v1/model2.json
+++ b/app/api/schemas/v1/model2.json
@@ -2,10 +2,23 @@
   "title": "Shema for data model 1",
   "type": "object",
   "properties": {
-    "pk": {"type": "string"},
-    "size": {"type":"number"},
     "modelName": {"type": "string"},
-    "version": {"type":"string"}
+    "pk": {"type": "string"},
+    "version": {"type": "string"},
+    "history": {
+      "type": "object",
+      "patternProperties": {
+        "d{4}-d{2}-d{2}": {
+          "type": "object",
+          "properties": {
+            "size": {"type": "string"},
+            "sizeB": {"type": "string"},
+            "sizeC": {"type": "string"}
+          },
+          "required": ["size"]
+        }
+      }
+    }
   },
-  "required": ["pk", "size", "modelName", "version"]
+  "required": ["pk", "version", "history", "modelName"]
 }

--- a/client/client.py
+++ b/client/client.py
@@ -32,10 +32,9 @@ except docker.errors.ImageNotFound:
     _, logs = dc.images.build(path='{}/putter/'.format(pwd), tag=DOCKER_IMAGE_NAME)
     print(logs)
 
-logs = dc.images.build(path='{}/putter/'.format(pwd), tag=DOCKER_IMAGE_NAME)
 c = dc.containers.run(
-    image='client-putter',
-    command='/putter_job.py {} /{} {}'.format(host, path, overwrite_if_exists),
+    image=DOCKER_IMAGE_NAME,
+    command='/putter_job.py {} /{}'.format(host, path),
     network_mode='host',
     remove=True,
     detach=True,

--- a/client/generate_jsonlines.py
+++ b/client/generate_jsonlines.py
@@ -3,6 +3,7 @@
 import pathlib
 import os
 import json
+import datetime
 from random import random
 
 os.makedirs('sample.jsonl/', exist_ok=True)
@@ -12,6 +13,17 @@ with open('sample.jsonl/afile', 'w') as f:
         model1 = {
             'pk': 'item_{}'.format(str(i)),
             'score': str(random()),
+            'buildDate': str(datetime.datetime.now().date() - datetime.timedelta(days=30)),
+            'modelName': 'model1',
+            'version': 'v1'
+        }
+        f.write(json.dumps(model1) + '\n')
+
+    for i in range(1, 5000):
+        model1 = {
+            'pk': 'item_{}'.format(str(i)),
+            'score': str(random()),
+            'buildDate': str(datetime.datetime.now().date()),
             'modelName': 'model1',
             'version': 'v1'
         }
@@ -21,6 +33,7 @@ with open('sample.jsonl/afile', 'w') as f:
         model2 = {
             'pk': 'item_{}'.format(i),
             'size': random(),
+            'buildDate': str(datetime.datetime.now().date()),
             'modelName': 'model2',
             'version': 'v1'
         }


### PR DESCRIPTION
Now, we're able to save historical data into API/Database.

- Use buildDate as key for historical data
- As we don't have a lot of buildDates, we can store it in object to
provide fast read access
- Remove all metadata from jsonline before saving
- Fix spark job counters - using accumulators now